### PR TITLE
Fix: Resolve Garbled Directory Icons in Starship Configuration

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -14,7 +14,7 @@ $character\
 """
 
 [directory]
-format = "[ ﱮ $path ]($style)"
+format = "[  $path ]($style)"
 style = "fg:#E4E4E4 bg:#3B76F0"
 
 [git_branch]


### PR DESCRIPTION
Corrected Misdisplayed Directory Icons in Starship Configuration.  #1 
![CleanShot 2025-01-04 at 01 07 21@2x](https://github.com/user-attachments/assets/41482d2d-bb6f-472c-8b8a-cf94a52a1767)
